### PR TITLE
Add "deprecated" library to requirements.txt files

### DIFF
--- a/agents/planner/requirements.txt
+++ b/agents/planner/requirements.txt
@@ -2,3 +2,4 @@ google-cloud-aiplatform[adk,agent_engines]>=1.90.0
 google-adk
 python-dateutil
 a2a_common-0.1.0-py3-none-any.whl
+deprecated==1.2.18

--- a/agents/platform_mcp_client/requirements.txt
+++ b/agents/platform_mcp_client/requirements.txt
@@ -7,3 +7,4 @@ humanize==4.12.3
 nest_asyncio==1.6.0
 asyncclick==8.1.8.0
 a2a_common-0.1.0-py3-none-any.whl
+deprecated==1.2.18

--- a/agents/social/requirements.txt
+++ b/agents/social/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv==1.1.0
 fastapi==0.115.12
 urllib3==2.4.0
 a2a_common-0.1.0-py3-none-any.whl
+deprecated==1.2.18

--- a/instavibe/requirements.txt
+++ b/instavibe/requirements.txt
@@ -2,3 +2,4 @@ google-cloud-aiplatform[adk,agent_engines]==1.91.0
 Flask==3.1.0
 google-cloud-spanner==3.54.0
 humanize==4.12.3
+deprecated==1.2.18


### PR DESCRIPTION
There are some issues with builds finishing correctly without the "deprecated" library being available in the environment.